### PR TITLE
Add instructions how to build and run

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+# Demo of Conrod floatwin on the browser with glow
+
+Build by running `wasm-pack build`. Then open `test.html` in your browser. You
+likely need to temporarily disable CORS, or the `.html` won't be able to load
+the `.js`.


### PR DESCRIPTION
Hi @alvinhochun,

I'm trying to get an end-to-end example of winit + web-sys running. I stumbled across this repo, and if it runs, it would be enough for me to make progress on https://github.com/dabreegster/abstreet/tree/websys.

Although this builds, when I open `test.html` in Firefox after disabling CORS, I get "Loading failed for the module with source “file:///home/dabreegster/Downloads/conrod_floatwin_demo_glow/pkg/conrod_floatwin_demo_glow_bg.wasm”.". I can't figure out what's breaking.

Assuming you've gotten this example working in the browser, mind helping with the instructions to reproduce it? Thanks!